### PR TITLE
feat: support copy _mock.js to mock

### DIFF
--- a/example/.umirc.js
+++ b/example/.umirc.js
@@ -3,5 +3,9 @@ import { join } from 'path';
 export default {
   plugins: [
     join(__dirname, '..', require('../package').main || 'index.js'),
+    ['umi-plugin-react', {
+      dva: true,
+      antd: true,
+    }],
   ],
 }

--- a/example/package.json
+++ b/example/package.json
@@ -7,5 +7,13 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "antd": "^3.11.2",
+    "react": "^16.6.3",
+    "umi-request": "^1.0.0"
+  },
+  "devDependencies": {
+    "umi-plugin-react": "^1.2.3"
+  }
 }

--- a/example/utils/request.js
+++ b/example/utils/request.js
@@ -1,0 +1,3 @@
+import request from 'umi-request';
+
+export default request;

--- a/package.json
+++ b/package.json
@@ -17,19 +17,20 @@
   "peerDependencies": {
     "umi": "2.x"
   },
-  
-  "main":  "lib/index.js",
+  "main": "lib/index.js",
   "scripts": {
-    "build":  "umi-tools build",
+    "build": "umi-tools build",
     "prepublishOnly": "npm run build && np --no-cleanup --yolo --no-publish"
   },
   "devDependencies": {
-    "umi-tools":  "*",
+    "umi-tools": "*",
     "np": "^3.0.4"
   },
   "files": [
     "lib",
     "src"
-  ]
-  
+  ],
+  "dependencies": {
+    "debug": "^4.1.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,15 @@
 // ref:
 // - https://umijs.org/plugin/develop.html
+import { join } from 'path';
 
-export default function (api, options) {
-
-  // Example: output the webpack config
-  api.chainWebpackConfig(config => {
-    console.log(config.toString());
+export default function (api) {
+  const { paths } = api;
+  api._modifyBlockTarget((target, { sourceName, blockPath }) => {
+    if (sourceName === '_mock.js') {
+      // /test/t/_mock.js -> test-t.js
+      const mockFileName = blockPath.replace(/^\//, '').replace(/\//g, '');
+      return join(paths.cwd, 'mock', `${mockFileName}.js`);
+    }
+    return target;
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,42 @@
 // ref:
 // - https://umijs.org/plugin/develop.html
 import { join } from 'path';
+import { existsSync } from 'fs';
+
+const debug = require('debug')('umi-plugin-pro-block');
 
 export default function (api) {
-  const { paths } = api;
-  api._modifyBlockTarget((target, { sourceName, blockPath }) => {
+  const { paths, config } = api;
+
+  let hasUtil, hasService, newFileName;
+  api.beforeBlockWriting(({ sourcePath, blockPath }) => {
+    hasUtil = existsSync(join(paths.absSrcPath, `util${config.singular ? '' : 's'}`, 'request.js'));
+    hasService = existsSync(join(sourcePath, './src/service.js'));
+    newFileName = blockPath.replace(/^\//, '').replace(/\//g, '');
+    debug('beforeBlockWriting... hasUtil:', hasUtil, 'hasService:', hasService, 'newFileName:', newFileName);
+  });
+
+  api._modifyBlockTarget((target, { sourceName }) => {
     if (sourceName === '_mock.js') {
-      // /test/t/_mock.js -> test-t.js
-      const mockFileName = blockPath.replace(/^\//, '').replace(/\//g, '');
-      return join(paths.cwd, 'mock', `${mockFileName}.js`);
+      // src/pages/test/t/_mock.js -> mock/test-t.js
+      return join(paths.cwd, 'mock', `${newFileName}.js`);
+    }
+    if (sourceName === 'service.js' && hasService) {
+      // src/pages/test/t/service.js -> services/test.t.js
+      return join(paths.absSrcPath, config.singular ? 'service' : 'services', `${newFileName}.js`);
     }
     return target;
+  });
+
+  // umi-request -> @utils/request
+  // src/pages/test/t/service.js -> services/test.t.js
+  api._modifyBlockFile((content) => {
+    if (hasUtil) {
+      content = content.replace(/[\'\"]umi\-request[\'\"]/g, `'@/util${config.singular ? '' : 's'}/request'`);
+    }
+    if (hasService) {
+      content = content.replace(/[\'\"][\.\/]+service[\'\"]/g, `'@/service${config.singular ? '' : 's'}/${newFileName}'`);
+    }
+    return content;
   });
 }


### PR DESCRIPTION
添加这个插件后，项目下载区块的时候会按照 pro 的实践来组织目录结构。

- [x] 把区块的 _mock 复制到最外层的  mock 文件夹中
- [x] 把区块的 service 复制到最外层的  services 文件夹中
- [x] 替换 umi-request 为 `utils/request`